### PR TITLE
bugfix: wrong message flow is created in some cases

### DIFF
--- a/src/main/java/ac/at/tuwien/infosys/visp/runtime/topology/rabbitMq/RabbitMqManager.java
+++ b/src/main/java/ac/at/tuwien/infosys/visp/runtime/topology/rabbitMq/RabbitMqManager.java
@@ -426,7 +426,7 @@ public class RabbitMqManager {
                 }
                 try {
                     LOG.debug("Adding message flow between operators " + source.getName() + " and " + update.getAffectedOperatorId());
-                    pair = Pair.of(source,
+                    pair = Pair.of(update.getAffectedOperator(),
                             addMessageFlow(source.getName(), update.getAffectedOperatorId(), source.getConcreteLocation().getIpAddress()));
                     if (pair != null) {
                         resultList.add(pair);
@@ -444,7 +444,7 @@ public class RabbitMqManager {
                 }
                 try {
                     LOG.debug("Adding message flow between operators " + update.getAffectedOperatorId() + " and " + downstreamOp.getName());
-                    pair = Pair.of(update.getAffectedOperator(),
+                    pair = Pair.of(downstreamOp,
                             addMessageFlow(update.getAffectedOperatorId(), downstreamOp.getName(), update.getAffectedOperator().getConcreteLocation().getIpAddress()));
                     if (pair != null) {
                         resultList.add(pair);


### PR DESCRIPTION
Before this bugfix, a topology update could have written to the wrong docker container which may have led to a circular message flow